### PR TITLE
Multiprocessing fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+  curl \
+  libmpv-dev \
+  python3-virtualenv \
+  python3-pip \
+  python-is-python3 \
+  yt-dlp \
+  && rm -rf /var/lib/apt/lists/*
+
+# TODO: build phantomjs instead? it's not happy
+# RUN curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 | tar -xj  && mv /phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/bin/  && rm /phantomjs-2.1.1-linux-x86_64 -rf
+
+COPY . /app
+RUN python -m pip install -r /app/requirements.txt
+
+
+WORKDIR /app
+#CMD python3 /app/main.py

--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
-from multiprocessing.synchronize import Event
-from multiprocessing.connection import Pipe as PipeConnection
 from tqdm import tqdm #type: ignore
-from typing import Callable, List, Literal, NoReturn, Tuple, TypedDict
+from typing import Callable, List, Literal, NoReturn, Tuple
 from pathlib import Path
 from smatter.media_out import save_srt
 import time

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from multiprocessing.synchronize import Event
-from multiprocessing.connection import PipeConnection
+from multiprocessing.connection import Pipe as PipeConnection
 from tqdm import tqdm #type: ignore
 from typing import Callable, List, Literal, NoReturn, Tuple, TypedDict
 from pathlib import Path

--- a/smatter/ff_process.py
+++ b/smatter/ff_process.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 from io import TextIOWrapper
-from multiprocessing.connection import Pipe as PipeConnection
+from multiprocessing.connection import _ConnectionBase
 from multiprocessing.synchronize import Event
-from typing import Any, Dict, List, TypeVar
 import multiprocessing as mp
 import ffmpeg as ff #type: ignore
 import loguru
@@ -106,7 +105,7 @@ def url_into_pcm_pipe(
     base_dir: str,
     url: str, 
     start: str, 
-    sync_pipe: PipeConnection | None):
+    sync_pipe: _ConnectionBase | None):
   """
   Uses yt-dlp and ffmpeg to produce a stream of pcm data
   from a source url.

--- a/smatter/ff_process.py
+++ b/smatter/ff_process.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from io import TextIOWrapper
-from multiprocessing.connection import PipeConnection
+from multiprocessing.connection import Pipe as PipeConnection
 from multiprocessing.synchronize import Event
 from typing import Any, Dict, List, TypeVar
 import multiprocessing as mp

--- a/smatter/mpv_show.py
+++ b/smatter/mpv_show.py
@@ -4,7 +4,7 @@ import loguru
 import time
 import queue
 import multiprocessing as mp
-from typing import Callable, Concatenate, Literal, ParamSpec, Tuples
+from typing import Callable, Concatenate, Literal, ParamSpec, Tuple
 from threading import Lock
 from smatter.utils import get_logger
 

--- a/smatter/mpv_show.py
+++ b/smatter/mpv_show.py
@@ -4,8 +4,7 @@ import loguru
 import time
 import queue
 import multiprocessing as mp
-from typing import Callable, Concatenate, Literal, ParamSpec, Tuple
-from multiprocessing.connection import PipeConnection
+from typing import Callable, Concatenate, Literal, ParamSpec, Tuples
 from threading import Lock
 from smatter.utils import get_logger
 

--- a/smatter/transx.py
+++ b/smatter/transx.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
-from multiprocessing.connection import Pipe as PipeConnection
+from multiprocessing.connection import _ConnectionBase
 import re, time, string
 from subprocess import Popen
 import numpy as np
 import numpy.typing as npt
 import multiprocessing as mp
-import threading as th
-from typing import IO, Callable, Generator, Literal, TypedDict, Tuple, List, Dict, Any
+from typing import Callable, Generator, Literal, TypedDict, Tuple, List, Dict, Any
 from multiprocessing.synchronize import Event
 from faster_whisper import WhisperModel
 from faster_whisper.transcribe import Segment
 from datetime import datetime, timedelta
 import loguru
-from loguru import logger
 from smatter.ff_process import url_into_pcm_pipe
 from libs.vad.utils_vad import VADIterator
 import smatter.utils as u
@@ -315,7 +313,7 @@ def vad_samples(
 def transx_from_audio_stream(
     transx_config: TransXConfig,
     whisper_config: WhisperConfig,
-    sync_pipe: PipeConnection | None,
+    sync_pipe: _ConnectionBase | None,
     ):
   """
   Get a stdout stream from ffmpeg based on the provided

--- a/smatter/transx.py
+++ b/smatter/transx.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from multiprocessing.connection import PipeConnection
+from multiprocessing.connection import Pipe as PipeConnection
 import re, time, string
 from subprocess import Popen
 import numpy as np

--- a/smatter/utils.py
+++ b/smatter/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import multiprocessing as mp, threading as th, time, loguru, re
 from multiprocessing.synchronize import Event
-from multiprocessing.connection import PipeConnection
 from typing import IO, TextIO
 from loguru import logger
 from tqdm import tqdm


### PR DESCRIPTION
Not sure what's different on my system, but multiprocessing.connection does not contain PipeConnection.
Did a quick alias of Pipe to PipeConnect and it worked, but did not investigate whether that was the correct thing to do.
Seems to work though!

I also removed a few of these imports entirely, where they were not used in that .py file.

Please don't merge this until we work out what's going on here.